### PR TITLE
feat: `Detail 페이지` UI 구현 및 API 연동

### DIFF
--- a/app/(home)/_components/todo-list.tsx
+++ b/app/(home)/_components/todo-list.tsx
@@ -45,7 +45,7 @@ const TodoList = ({ type, allItems, setAllItems }: TodoListProps) => {
   // 아이템이 없는 경우 데이터 없음 이미지 렌더링
   if (!items.length)
     return (
-      <div className="grow">
+      <div className="w-full">
         <Image src={LIST_TYPE[type].labelImg} alt={`${type}Label`} />
         <div className="flex flex-col items-center gap-[24px] pc:mt-[64px]">
           <Image

--- a/app/(home)/page.tsx
+++ b/app/(home)/page.tsx
@@ -15,7 +15,7 @@ const Home = () => {
   }, []);
 
   return (
-    <div className="py-[16px] tablet:py-[24px]">
+    <div className="mx-auto max-w-[1200px] px-[16px] py-[16px] tablet:px-[24px] tablet:py-[24px]">
       {/* 할 일 추가 섹션 */}
       <AddInput setAllItems={setAllItems} />
 

--- a/app/globals.css
+++ b/app/globals.css
@@ -13,9 +13,6 @@
 }
 
 @layer base {
-  input {
-    field-sizing: content;
-  }
 }
 
 @layer utilities {

--- a/app/globals.css
+++ b/app/globals.css
@@ -16,6 +16,10 @@
 }
 
 @layer utilities {
+  /* Memo textarea 커스텀 스크롤바 */
+  .memo-scroll-bar {
+    @apply rounded-[3px] [&::-webkit-scrollbar-thumb]:cursor-pointer [&::-webkit-scrollbar-thumb]:bg-amber-200 [&::-webkit-scrollbar-track]:bg-transparent [&::-webkit-scrollbar]:w-[4px];
+  }
 }
 
 @layer components {

--- a/app/globals.css
+++ b/app/globals.css
@@ -13,6 +13,9 @@
 }
 
 @layer base {
+  input {
+    field-sizing: content;
+  }
 }
 
 @layer utilities {

--- a/app/items/[id]/page.tsx
+++ b/app/items/[id]/page.tsx
@@ -1,14 +1,19 @@
 "use client";
 
-import { useParams } from "next/navigation";
+import { useParams, useRouter } from "next/navigation";
 import imgNullIcon from "../../../public/imgs/img-null.svg";
 import ActionBtn from "../../../components/action-btn";
 import Image from "next/image";
 import EditImgBtn from "../../../components/edit-img-btn";
 import TodoItemDetail from "../../../components/todo-item-detail";
-import { getItem, updateItem } from "../../../services/apis/itemApi";
+import {
+  deleteItem,
+  getItem,
+  updateItem,
+} from "../../../services/apis/itemApi";
 import { useEffect, useState } from "react";
 import { Item } from "../../../types/ItemType";
+import { HOME_PAGE_ROUTE } from "../../../constants/routes";
 
 const Detail = () => {
   const params = useParams();
@@ -16,6 +21,22 @@ const Detail = () => {
 
   const [item, setItem] = useState<Item>();
   const [memo, setMemo] = useState<string>("");
+  const router = useRouter();
+
+  const handleDelete = () => {
+    // 삭제 확인 모달 표시
+    if (confirm(`"${item?.name}" 할 일을 삭제하시겠습니까?`)) {
+      deleteItem(id)
+        .then(() => {
+          // 아이템 삭제 후 홈으로 이동
+          alert("삭제 완료하였습니다.");
+          router.push(HOME_PAGE_ROUTE);
+        })
+        .catch(() => {
+          alert("삭제에 실패하였습니다.");
+        });
+    }
+  };
 
   const handleClickCheckBtn = () => {
     // 현재 아이템에서 complete 변경 => 낙관적 업데이트
@@ -64,7 +85,7 @@ const Detail = () => {
             Memo
           </span>
           <textarea
-            value={memo}
+            value={memo || ""}
             onChange={(e) => {
               setMemo(e.currentTarget.value);
             }}
@@ -76,7 +97,7 @@ const Detail = () => {
       {/* 버튼 섹션*/}
       <section className="flex items-center justify-center gap-[7px] tablet:gap-[16px] pc:justify-end">
         <ActionBtn type="edit" active={true} onClick={() => {}} />
-        <ActionBtn type="delete" onClick={() => {}} />
+        <ActionBtn type="delete" onClick={handleDelete} />
       </section>
     </div>
   );

--- a/app/items/[id]/page.tsx
+++ b/app/items/[id]/page.tsx
@@ -1,0 +1,53 @@
+"use client";
+
+import { useParams } from "next/navigation";
+import imgNullIcon from "../../../public/imgs/img-null.svg";
+import memoImg from "../../../public/imgs/memo.svg";
+
+import ActionBtn from "../../../components/action-btn";
+import Image from "next/image";
+import EditImgBtn from "../../../components/edit-img-btn";
+import TodoItemDetail from "../../../components/todo-item-detail";
+
+const Detail = () => {
+  const params = useParams();
+  console.log(params.id);
+
+  return (
+    <div className="py-[16px] tablet:py-[24px] pc:px-[120px]">
+      {/* Todo 타이틀 섹션*/}
+      <section className="mb-[17px] tablet:mb-[24px]">
+        <TodoItemDetail text="비타민 챙겨 먹기" isDone={true} />
+      </section>
+
+      {/* 이미지 & 메모 섹션 */}
+      <section className="mb-[24px] flex flex-col items-center justify-center gap-[15px] tablet:gap-[24px] pc:flex-row">
+        <div className="relative flex h-[311px] w-full shrink-0 items-center justify-center rounded-[24px] border-2 border-dashed border-slate-300 bg-slate-50 pc:w-[384px]">
+          <Image src={imgNullIcon} alt="imgNullIcon" />
+          <EditImgBtn
+            className="absolute bottom-[16px] right-[16px]"
+            onClick={() => {}}
+            type="add"
+          />
+        </div>
+        <div className="relative flex h-[311px] w-full items-center justify-center rounded-[24px] bg-[url('/imgs/memo.svg')]">
+          <h1 className="absolute left-[50%] right-[50%] top-[24px] mx-auto w-fit translate-x-[-50%] transform font-nanumsquare-bold text-16px font-extrabold text-amber-800">
+            Memo
+          </h1>
+          <input
+            type="text"
+            className="m-[16px] mt-[58px] h-[229px] w-full bg-transparent text-center font-nanumsquare-regular text-16px outline-none [border:1px_solid_black]"
+          />
+        </div>
+      </section>
+
+      {/* 버튼 섹션*/}
+      <section className="flex items-center justify-center gap-[7px] tablet:gap-[16px] pc:justify-end">
+        <ActionBtn type="edit" active={true} onClick={() => {}} />
+        <ActionBtn type="delete" onClick={() => {}} />
+      </section>
+    </div>
+  );
+};
+
+export default Detail;

--- a/app/items/[id]/page.tsx
+++ b/app/items/[id]/page.tsx
@@ -105,7 +105,7 @@ const Detail = () => {
   }, []);
 
   return (
-    <div className="py-[16px] tablet:py-[24px] pc:w-[1200px] pc:px-[120px]">
+    <div className="mx-auto min-h-[calc(100vh-60px)] bg-white px-[16px] py-[16px] tablet:px-[24px] tablet:py-[24px] pc:w-[1200px] pc:px-[120px]">
       {/* Todo 이름 섹션*/}
       <section className="mb-[17px] tablet:mb-[24px]">
         <TodoItemDetail

--- a/app/items/[id]/page.tsx
+++ b/app/items/[id]/page.tsx
@@ -12,9 +12,10 @@ import {
   updateItem,
   UpdateItemProps,
 } from "../../../services/apis/itemApi";
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { Item } from "../../../types/ItemType";
 import { HOME_PAGE_ROUTE } from "../../../constants/routes";
+import { uploadImage } from "../../../services/apis/imageApi";
 
 const Detail = () => {
   const router = useRouter();
@@ -23,6 +24,7 @@ const Detail = () => {
 
   const [item, setItem] = useState<Item>();
   const [isEditing, setIsEditing] = useState(false);
+  const fileInputRef = useRef<HTMLInputElement>(null);
 
   const handleDelete = () => {
     // 삭제 확인 모달 표시
@@ -48,7 +50,6 @@ const Detail = () => {
       isCompleted,
       name,
     };
-
     // Update API 호출
     updateItem(id, updatedItem)
       .then(() => {
@@ -68,6 +69,34 @@ const Detail = () => {
     });
   };
 
+  const handleFileUpload = async (e: React.ChangeEvent<HTMLInputElement>) => {
+    setIsEditing(true);
+    const file = e.target.files?.[0];
+    if (file) {
+      // 파일 이름 영어로만 이루어져 있는지 확인
+      const isEnglishOnly = /^[a-zA-Z.]+$/.test(file.name);
+      if (!isEnglishOnly) {
+        alert("파일 이름은 영어로만 구성되어야 합니다.");
+        return;
+      }
+      // 크기 제한 (5MB 이하 확인)
+      if (file.size > 5 * 1024 * 1024) {
+        alert("파일 크기가 5MB를 초과합니다.");
+        return;
+      }
+
+      // 파일을 폼데이터 형식으로 변환
+      const formData = new FormData();
+      formData.append("image", file);
+
+      // 이미지 링크 받아오기
+      const uploadedImageUrl = await uploadImage(formData);
+
+      // 아이템 업데이트
+      setItem((item) => ({ ...item, imageUrl: uploadedImageUrl }) as Item);
+    }
+  };
+
   useEffect(() => {
     // 상세정보 API 호출
     getItem(id).then((data) => {
@@ -77,7 +106,7 @@ const Detail = () => {
 
   return (
     <div className="py-[16px] tablet:py-[24px] pc:w-[1200px] pc:px-[120px]">
-      {/* Todo 타이틀 섹션*/}
+      {/* Todo 이름 섹션*/}
       <section className="mb-[17px] tablet:mb-[24px]">
         <TodoItemDetail
           setItem={setItem}
@@ -90,15 +119,39 @@ const Detail = () => {
 
       {/* 이미지 & 메모 섹션 */}
       <section className="mb-[24px] flex flex-col items-center justify-center gap-[15px] tablet:gap-[24px] pc:flex-row">
-        <div className="relative flex h-[311px] w-full shrink-0 items-center justify-center rounded-[24px] border-2 border-dashed border-slate-300 bg-slate-50 pc:w-[384px]">
-          <Image src={imgNullIcon} alt="imgNullIcon" />
+        <div
+          className={`relative flex h-[311px] w-full shrink-0 items-center justify-center rounded-[24px] border-2 border-dashed border-slate-300 bg-slate-50 pc:w-[384px]`}
+        >
+          {/* 이미지 존재 여부에 따라 조건부 렌더링*/}
+          {item?.imageUrl ? (
+            <Image
+              className="rounded-[24px] object-cover"
+              src={item?.imageUrl}
+              alt={item?.imageUrl}
+              fill
+            />
+          ) : (
+            <Image src={imgNullIcon} alt="imgNullIcon" />
+          )}
+
           <EditImgBtn
             className="absolute bottom-[16px] right-[16px]"
-            onClick={handleUploadImgBtn}
-            type="add"
+            onClick={() => fileInputRef.current!.click()}
+            type={item?.imageUrl ? "edit" : "add"}
+          />
+
+          {/* 이미지 업로드 input태그 숨기기 */}
+          <input
+            type="file"
+            accept="image/*"
+            ref={fileInputRef}
+            className="hidden"
+            onChange={handleFileUpload}
           />
         </div>
-        <div className="relative flex h-[311px] w-full items-center justify-center rounded-[24px] bg-[url('/imgs/memo.svg')]">
+        <div
+          className={`relative flex h-[311px] w-full items-center justify-center rounded-[24px] bg-[url('/imgs/memo.svg')]`}
+        >
           <span className="absolute left-[50%] right-[50%] top-[24px] mx-auto w-fit translate-x-[-50%] transform font-nanumsquare-bold text-16px font-extrabold text-amber-800">
             Memo
           </span>

--- a/app/items/[id]/page.tsx
+++ b/app/items/[id]/page.tsx
@@ -2,22 +2,51 @@
 
 import { useParams } from "next/navigation";
 import imgNullIcon from "../../../public/imgs/img-null.svg";
-import memoImg from "../../../public/imgs/memo.svg";
-
 import ActionBtn from "../../../components/action-btn";
 import Image from "next/image";
 import EditImgBtn from "../../../components/edit-img-btn";
 import TodoItemDetail from "../../../components/todo-item-detail";
+import { getItem, updateItem } from "../../../services/apis/itemApi";
+import { useEffect, useState } from "react";
+import { Item } from "../../../types/ItemType";
 
 const Detail = () => {
   const params = useParams();
-  console.log(params.id);
+  const id = Number(params.id);
+
+  const [item, setItem] = useState<Item>();
+  const [memo, setMemo] = useState<string>("");
+
+  const handleClickCheckBtn = () => {
+    // 현재 아이템에서 complete 변경 => 낙관적 업데이트
+    setItem((item) => {
+      return { ...item, isCompleted: !item?.isCompleted } as Item;
+    });
+
+    // patch API 호출
+    updateItem(id, { isCompleted: !item?.isCompleted }).catch(() => {
+      alert("할 일 상태 변경에 실패하였습니다.");
+      location.reload();
+    });
+  };
+
+  useEffect(() => {
+    // 상세정보 API 호출
+    getItem(id).then((data) => {
+      setItem(data);
+      setMemo(data.memo);
+    });
+  }, []);
 
   return (
-    <div className="py-[16px] tablet:py-[24px] pc:px-[120px]">
+    <div className="py-[16px] tablet:py-[24px] pc:w-[1200px] pc:px-[120px]">
       {/* Todo 타이틀 섹션*/}
       <section className="mb-[17px] tablet:mb-[24px]">
-        <TodoItemDetail text="비타민 챙겨 먹기" isDone={true} />
+        <TodoItemDetail
+          onClick={handleClickCheckBtn}
+          text={item?.name}
+          isDone={item?.isCompleted}
+        />
       </section>
 
       {/* 이미지 & 메모 섹션 */}
@@ -31,12 +60,15 @@ const Detail = () => {
           />
         </div>
         <div className="relative flex h-[311px] w-full items-center justify-center rounded-[24px] bg-[url('/imgs/memo.svg')]">
-          <h1 className="absolute left-[50%] right-[50%] top-[24px] mx-auto w-fit translate-x-[-50%] transform font-nanumsquare-bold text-16px font-extrabold text-amber-800">
+          <span className="absolute left-[50%] right-[50%] top-[24px] mx-auto w-fit translate-x-[-50%] transform font-nanumsquare-bold text-16px font-extrabold text-amber-800">
             Memo
-          </h1>
-          <input
-            type="text"
-            className="m-[16px] mt-[58px] h-[229px] w-full bg-transparent text-center font-nanumsquare-regular text-16px outline-none [border:1px_solid_black]"
+          </span>
+          <textarea
+            value={memo}
+            onChange={(e) => {
+              setMemo(e.currentTarget.value);
+            }}
+            className="memo-scroll-bar m-[16px] mt-[58px] h-[229px] w-full resize-none bg-transparent pr-[12px] text-center font-nanumsquare-regular text-16px outline-none"
           />
         </div>
       </section>

--- a/app/items/[id]/page.tsx
+++ b/app/items/[id]/page.tsx
@@ -1,116 +1,35 @@
 "use client";
 
-import { useParams, useRouter } from "next/navigation";
-import imgNullIcon from "../../../public/imgs/img-null.svg";
+import { useParams } from "next/navigation";
 import ActionBtn from "../../../components/action-btn";
-import Image from "next/image";
 import EditImgBtn from "../../../components/edit-img-btn";
 import TodoItemDetail from "../../../components/todo-item-detail";
-import {
-  deleteItem,
-  getItem,
-  updateItem,
-  UpdateItemProps,
-} from "../../../services/apis/itemApi";
-import { useEffect, useRef, useState } from "react";
+import { useImageUpload } from "../../../hooks/useImageUpload";
+import { useItemDetail } from "../../../hooks/useItemDetail";
 import { Item } from "../../../types/ItemType";
-import { HOME_PAGE_ROUTE } from "../../../constants/routes";
-import { uploadImage } from "../../../services/apis/imageApi";
+import imgNullIcon from "../../../public/imgs/img-null.svg";
+import Image from "next/image";
 
 const Detail = () => {
-  const router = useRouter();
   const params = useParams();
   const id = Number(params.id);
 
-  const [item, setItem] = useState<Item>();
-  const [isEditing, setIsEditing] = useState(false);
-  const fileInputRef = useRef<HTMLInputElement>(null);
+  // 아이템 조회, 수정, 삭제 커스텀 훅
+  const { item, setItem, isEditing, setIsEditing, handleEdit, handleDelete } =
+    useItemDetail(id);
 
-  const handleDelete = () => {
-    // 삭제 확인 모달 표시
-    if (confirm(`"${item?.name}" 할 일을 삭제하시겠습니까?`)) {
-      deleteItem(id)
-        .then(() => {
-          // 아이템 삭제 후 홈으로 이동
-          alert("삭제 완료하였습니다.");
-          router.push(HOME_PAGE_ROUTE);
-        })
-        .catch(() => {
-          alert("삭제에 실패하였습니다.");
-        });
-    }
-  };
-
-  const handleEdit = () => {
-    // 현재 아이템에서 API 호출에 필요한 속성만 추출
-    const { imageUrl, isCompleted, memo, name } = item!;
-    const updatedItem: UpdateItemProps = {
-      imageUrl: imageUrl || "",
-      memo: memo || "",
-      isCompleted,
-      name,
-    };
-    // Update API 호출
-    updateItem(id, updatedItem)
-      .then(() => {
-        alert("수정 완료하였습니다.");
-        router.push(HOME_PAGE_ROUTE);
-      })
-      .catch(() => {
-        alert("수정에 실패하였습니다.");
-      });
-  };
-
-  // 할 일 상태 변경
-  const handleClickCheckBtn = () => {
-    setIsEditing(true);
-    setItem((item) => {
-      return { ...item, isCompleted: !item?.isCompleted } as Item;
-    });
-  };
-
-  const handleFileUpload = async (e: React.ChangeEvent<HTMLInputElement>) => {
-    setIsEditing(true);
-    const file = e.target.files?.[0];
-    if (file) {
-      // 파일 이름 영어로만 이루어져 있는지 확인
-      const isEnglishOnly = /^[a-zA-Z.]+$/.test(file.name);
-      if (!isEnglishOnly) {
-        alert("파일 이름은 영어로만 구성되어야 합니다.");
-        return;
-      }
-      // 크기 제한 (5MB 이하 확인)
-      if (file.size > 5 * 1024 * 1024) {
-        alert("파일 크기가 5MB를 초과합니다.");
-        return;
-      }
-
-      // 파일을 폼데이터 형식으로 변환
-      const formData = new FormData();
-      formData.append("image", file);
-
-      // 이미지 링크 받아오기
-      const uploadedImageUrl = await uploadImage(formData);
-
-      // 아이템 업데이트
-      setItem((item) => ({ ...item, imageUrl: uploadedImageUrl }) as Item);
-    }
-  };
-
-  useEffect(() => {
-    // 상세정보 API 호출
-    getItem(id).then((data) => {
-      setItem(data);
-    });
-  }, []);
+  // 파일 업로드 커스텀 훅
+  const { fileInputRef, handleFileUpload } = useImageUpload(
+    setItem,
+    setIsEditing,
+  );
 
   return (
     <div className="mx-auto min-h-[calc(100vh-60px)] bg-white px-[16px] py-[16px] tablet:px-[24px] tablet:py-[24px] pc:w-[1200px] pc:px-[120px]">
-      {/* Todo 이름 섹션*/}
+      {/* Todo 이름 섹션 */}
       <section className="mb-[17px] tablet:mb-[24px]">
         <TodoItemDetail
           setItem={setItem}
-          onClick={handleClickCheckBtn}
           name={item?.name}
           isDone={item?.isCompleted}
           setIsEditing={setIsEditing}
@@ -122,12 +41,11 @@ const Detail = () => {
         <div
           className={`relative flex h-[311px] w-full shrink-0 items-center justify-center rounded-[24px] border-2 border-dashed border-slate-300 bg-slate-50 pc:w-[384px]`}
         >
-          {/* 이미지 존재 여부에 따라 조건부 렌더링*/}
           {item?.imageUrl ? (
             <Image
               className="rounded-[24px] object-cover"
-              src={item?.imageUrl}
-              alt={item?.imageUrl}
+              src={item.imageUrl}
+              alt={item.imageUrl}
               fill
             />
           ) : (
@@ -140,7 +58,6 @@ const Detail = () => {
             type={item?.imageUrl ? "edit" : "add"}
           />
 
-          {/* 이미지 업로드 input태그 숨기기 */}
           <input
             type="file"
             accept="image/*"
@@ -158,17 +75,17 @@ const Detail = () => {
           <textarea
             value={item?.memo || ""}
             onChange={(e) => {
-              setItem((item) => {
+              setItem((prevItem) => {
                 setIsEditing(true);
-                return { ...item, memo: e.target.value } as Item;
+                return { ...prevItem, memo: e.target.value } as Item;
               });
             }}
-            className="memo-scroll-bar m-[16px] mt-[58px] h-[229px] w-full resize-none bg-transparent pr-[12px] text-center font-nanumsquare-regular text-16px outline-none"
+            className="memo-scroll-bar m-[16px] mt-[58px] h-[229px] w-full cursor-pointer resize-none bg-transparent pr-[12px] text-center font-nanumsquare-regular text-16px outline-none"
           />
         </div>
       </section>
 
-      {/* 버튼 섹션*/}
+      {/* 버튼 섹션 */}
       <section className="flex items-center justify-center gap-[7px] tablet:gap-[16px] pc:justify-end">
         <ActionBtn type="edit" active={isEditing} onClick={handleEdit} />
         <ActionBtn type="delete" onClick={handleDelete} />

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -19,7 +19,7 @@ export default function RootLayout({
     <html lang="en">
       <body className="mx-auto max-w-[1200px] px-[16px] tablet:px-[24px]">
         <Gnb />
-        {children}
+        <div>{children}</div>
       </body>
     </html>
   );

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -17,9 +17,11 @@ export default function RootLayout({
 }>) {
   return (
     <html lang="en">
-      <body className="mx-auto max-w-[1200px] px-[16px] tablet:px-[24px]">
+      <body className="">
         <Gnb />
-        <div>{children}</div>
+        <div className="mx-auto min-h-[calc(100vh-60px)] bg-gray-50">
+          <div>{children}</div>
+        </div>
       </body>
     </html>
   );

--- a/components/action-btn.tsx
+++ b/components/action-btn.tsx
@@ -39,7 +39,7 @@ interface ActionBtnProps {
 
 // 타입별로 재사용 가능한 버튼
 // add 타입의 경우 480px을 기준으로 UI가 변경되도록 반응형 구현
-const ActionBtn = ({ type, active = false, onClick }: ActionBtnProps) => {
+const ActionBtn = ({ type, active = true, onClick }: ActionBtnProps) => {
   // 버튼 타입과 활성화 상태에 따라 적절한 아이콘 선택
   const icon =
     type === "add" ? ICONS[type][active ? "active" : "inactive"] : ICONS[type];

--- a/components/edit-img-btn.tsx
+++ b/components/edit-img-btn.tsx
@@ -10,13 +10,14 @@ const BUTTON_STYLE = {
 interface EditImgBtnProps {
   type: "add" | "edit";
   onClick: () => void;
+  className?: string;
 }
 
-const EditImgBtn = ({ type, onClick }: EditImgBtnProps) => {
+const EditImgBtn = ({ type, onClick, className }: EditImgBtnProps) => {
   return (
     <button
       onClick={onClick}
-      className={`flex size-[64px] items-center justify-center rounded-full ${BUTTON_STYLE[type]}`}
+      className={`flex size-[64px] items-center justify-center rounded-full ${BUTTON_STYLE[type]} ${className}`}
     >
       <Image src={type === "add" ? addIcon : editIcon} alt={`${type}Icon`} />
     </button>

--- a/components/gnb.tsx
+++ b/components/gnb.tsx
@@ -7,7 +7,7 @@ import { HOME_PAGE_ROUTE } from "../constants/routes";
 const Gnb = () => {
   return (
     <>
-      <nav className="flex h-[60px] items-center bg-white">
+      <nav className="m-auto flex h-[60px] max-w-[1200px] items-center bg-white px-[16px] tablet:px-[24px]">
         <Link href={HOME_PAGE_ROUTE}>
           {/* 모바일 환경에서는 텍스트가 없는 로고 사용 */}
           <Image src={logoSmall} alt="logoSmall" className="tablet:hidden" />

--- a/components/todo-item-detail.tsx
+++ b/components/todo-item-detail.tsx
@@ -1,19 +1,37 @@
 import Image from "next/image";
 import todoCircle from "../public/icons/todo-circle.svg";
 import doneCircle from "../public/icons/done-circle.svg";
+import { ChangeEvent, Dispatch, SetStateAction } from "react";
+import { Item } from "../types/ItemType";
 
 interface TodoItemDetailProps {
   isDone?: boolean;
-  text?: string;
+  name?: string;
   onClick: () => void;
+  setItem: Dispatch<SetStateAction<Item | undefined>>;
+  setIsEditing: Dispatch<SetStateAction<boolean>>;
 }
 
-const TodoItemDetail = ({ onClick, isDone, text }: TodoItemDetailProps) => {
+const TodoItemDetail = ({
+  onClick,
+  isDone,
+  name,
+  setItem,
+  setIsEditing,
+}: TodoItemDetailProps) => {
   // 완료 여부에 따른 배경색 적용
   const bgStyle = isDone ? "bg-violet-200" : "bg-white";
 
   // 완료 여부에 따른 아이콘 적용
   const checkIcon = isDone ? doneCircle : todoCircle;
+
+  // 할 일 이름 변경
+  const handleNameChange = (e: ChangeEvent<HTMLInputElement>) => {
+    setIsEditing(true);
+    setItem((item) => {
+      return { ...item, name: e.target.value } as Item;
+    });
+  };
 
   return (
     <div
@@ -25,7 +43,11 @@ const TodoItemDetail = ({ onClick, isDone, text }: TodoItemDetailProps) => {
         alt={"check or not"}
         onClick={onClick}
       />
-      <span className="font-nanumsquare-bold text-20px underline">{text}</span>
+      <input
+        className="cursor-pointer bg-transparent font-nanumsquare-bold text-20px underline outline-none"
+        value={name || ""}
+        onChange={handleNameChange}
+      />
     </div>
   );
 };

--- a/components/todo-item-detail.tsx
+++ b/components/todo-item-detail.tsx
@@ -7,13 +7,11 @@ import { Item } from "../types/ItemType";
 interface TodoItemDetailProps {
   isDone?: boolean;
   name?: string;
-  onClick: () => void;
   setItem: Dispatch<SetStateAction<Item | undefined>>;
   setIsEditing: Dispatch<SetStateAction<boolean>>;
 }
 
 const TodoItemDetail = ({
-  onClick,
   isDone,
   name,
   setItem,
@@ -24,6 +22,14 @@ const TodoItemDetail = ({
 
   // 완료 여부에 따른 아이콘 적용
   const checkIcon = isDone ? doneCircle : todoCircle;
+
+  // 완료 상태 변경
+  const handleClickCheckBtn = () => {
+    setIsEditing(true);
+    setItem((item) => {
+      return { ...item, isCompleted: !item?.isCompleted } as Item;
+    });
+  };
 
   // 할 일 이름 변경
   const handleNameChange = (e: ChangeEvent<HTMLInputElement>) => {
@@ -43,7 +49,7 @@ const TodoItemDetail = ({
         className="cursor-pointer"
         src={checkIcon}
         alt={"check or not"}
-        onClick={onClick}
+        onClick={handleClickCheckBtn}
       />
       <input
         className="max-w-[76%] cursor-pointer bg-transparent font-nanumsquare-bold text-20px underline outline-none [field-sizing:content] tablet:max-w-[86%]"

--- a/components/todo-item-detail.tsx
+++ b/components/todo-item-detail.tsx
@@ -28,6 +28,8 @@ const TodoItemDetail = ({
   // 할 일 이름 변경
   const handleNameChange = (e: ChangeEvent<HTMLInputElement>) => {
     setIsEditing(true);
+    if (e.target.value.length === 0)
+      return alert("제목을 한 글자 이상 입력해주세요.");
     setItem((item) => {
       return { ...item, name: e.target.value } as Item;
     });
@@ -44,7 +46,7 @@ const TodoItemDetail = ({
         onClick={onClick}
       />
       <input
-        className="cursor-pointer bg-transparent font-nanumsquare-bold text-20px underline outline-none"
+        className="max-w-[76%] cursor-pointer bg-transparent font-nanumsquare-bold text-20px underline outline-none [field-sizing:content] tablet:max-w-[86%]"
         value={name || ""}
         onChange={handleNameChange}
       />

--- a/components/todo-item-detail.tsx
+++ b/components/todo-item-detail.tsx
@@ -3,18 +3,17 @@ import todoCircle from "../public/icons/todo-circle.svg";
 import doneCircle from "../public/icons/done-circle.svg";
 
 interface TodoItemDetailProps {
-  isDone: boolean;
-  text: string;
+  isDone?: boolean;
+  text?: string;
+  onClick: () => void;
 }
 
-const TodoItemDetail = ({ isDone, text }: TodoItemDetailProps) => {
+const TodoItemDetail = ({ onClick, isDone, text }: TodoItemDetailProps) => {
   // 완료 여부에 따른 배경색 적용
   const bgStyle = isDone ? "bg-violet-200" : "bg-white";
 
   // 완료 여부에 따른 아이콘 적용
   const checkIcon = isDone ? doneCircle : todoCircle;
-
-  const handleClickCheckBtn = () => {};
 
   return (
     <div
@@ -24,7 +23,7 @@ const TodoItemDetail = ({ isDone, text }: TodoItemDetailProps) => {
         className="cursor-pointer"
         src={checkIcon}
         alt={"check or not"}
-        onClick={handleClickCheckBtn}
+        onClick={onClick}
       />
       <span className="font-nanumsquare-bold text-20px underline">{text}</span>
     </div>

--- a/components/todo-item.tsx
+++ b/components/todo-item.tsx
@@ -64,7 +64,7 @@ const TodoItem = ({ isDone, text, itemId, setAllItems }: TodoItemProps) => {
       />
       <Link
         href={`${TODO_DETAIL_ROUTE}/${itemId}`}
-        className={`font-nanumsquare-regular text-16px ${style.textStyle}`}
+        className={`w-full font-nanumsquare-regular text-16px ${style.textStyle}`}
       >
         {/* text를 최대 50자 까지만 보여줌 */}
         {text.length >= 50 ? `${text.slice(0, 50)}...` : text}

--- a/hooks/useImageUpload.ts
+++ b/hooks/useImageUpload.ts
@@ -1,0 +1,44 @@
+import { Dispatch, SetStateAction, useRef } from "react";
+import { uploadImage } from "../services/apis/imageApi";
+import { Item } from "../types/ItemType";
+
+export const useImageUpload = (
+  setItem: React.Dispatch<React.SetStateAction<Item | undefined>>,
+  setIsEditing: Dispatch<SetStateAction<boolean>>,
+) => {
+  const fileInputRef = useRef<HTMLInputElement>(null);
+
+  const handleFileUpload = async (e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0];
+    if (!file) return;
+
+    // 파일 이름 영어로만 이루어져 있는지 확인
+    const isEnglishOnly = /^[a-zA-Z.]+$/.test(file.name);
+    if (!isEnglishOnly) {
+      alert("파일 이름은 영어로만 구성되어야 합니다.");
+      return;
+    }
+
+    // 크기 제한 (5MB 이하 확인)
+    if (file.size > 5 * 1024 * 1024) {
+      alert("파일 크기가 5MB를 초과합니다.");
+      return;
+    }
+
+    // 파일을 폼데이터 형식으로 변환
+    const formData = new FormData();
+    formData.append("image", file);
+
+    // 이미지 링크 받아오기
+    const uploadedImageUrl = await uploadImage(formData);
+
+    // 아이템 업데이트
+    setItem(
+      (prevItem) => ({ ...prevItem, imageUrl: uploadedImageUrl }) as Item,
+    );
+
+    setIsEditing(true);
+  };
+
+  return { fileInputRef, handleFileUpload };
+};

--- a/hooks/useItemDetail.ts
+++ b/hooks/useItemDetail.ts
@@ -1,0 +1,61 @@
+import { useState, useEffect } from "react";
+import { HOME_PAGE_ROUTE } from "../constants/routes";
+import {
+  getItem,
+  UpdateItemProps,
+  updateItem,
+  deleteItem,
+} from "../services/apis/itemApi";
+import { Item } from "../types/ItemType";
+import { useRouter } from "next/navigation";
+
+export const useItemDetail = (id: number) => {
+  const [item, setItem] = useState<Item>();
+  const [isEditing, setIsEditing] = useState(false);
+  const router = useRouter();
+
+  useEffect(() => {
+    // 아이템 상세정보 API 호출
+    getItem(id).then((data) => setItem(data));
+  }, [id]);
+
+  const handleEdit = () => {
+    if (!item) return;
+
+    // 현재 아이템에서 API 호출에 필요한 속성만 추출
+    const { imageUrl, isCompleted, memo, name } = item;
+    const updatedItem: UpdateItemProps = {
+      imageUrl: imageUrl || "",
+      memo: memo || "",
+      isCompleted,
+      name,
+    };
+
+    // Update API 호출
+    updateItem(id, updatedItem)
+      .then(() => {
+        alert("수정을 완료하였습니다.");
+        router.push(HOME_PAGE_ROUTE);
+      })
+      .catch(() => {
+        alert("수정에 실패하였습니다.");
+      });
+  };
+
+  const handleDelete = () => {
+    // 삭제 확인 모달 표시
+    if (confirm(`"${item?.name}" 할 일을 삭제하시겠습니까?`)) {
+      deleteItem(id)
+        .then(() => {
+          // 아이템 삭제 후 홈으로 이동
+          alert("삭제 완료하였습니다.");
+          router.push(HOME_PAGE_ROUTE);
+        })
+        .catch(() => {
+          alert("삭제에 실패하였습니다.");
+        });
+    }
+  };
+
+  return { item, setItem, isEditing, setIsEditing, handleEdit, handleDelete };
+};

--- a/next.config.ts
+++ b/next.config.ts
@@ -1,7 +1,16 @@
 import type { NextConfig } from "next";
 
 const nextConfig: NextConfig = {
-  /* config options here */
+  images: {
+    remotePatterns: [
+      {
+        protocol: "https",
+        hostname: "sprint-fe-project.s3.ap-northeast-2.amazonaws.com",
+        port: "",
+        pathname: "/**",
+      },
+    ],
+  },
 };
 
 export default nextConfig;

--- a/services/apis/imageApi.ts
+++ b/services/apis/imageApi.ts
@@ -6,6 +6,7 @@ interface UploadImageResponse {
 
 // 이미지 업로드
 export const uploadImage = async (formData: FormData) => {
+  console.log([...formData.entries()]);
   const response = await axiosInstance.post<UploadImageResponse>(
     `/images/upload`,
     formData,
@@ -13,7 +14,7 @@ export const uploadImage = async (formData: FormData) => {
       headers: {
         "Content-Type": "multipart/form-data",
       },
-    }
+    },
   );
-  return response.data;
+  return response.data.url;
 };

--- a/services/apis/itemApi.ts
+++ b/services/apis/itemApi.ts
@@ -27,7 +27,7 @@ export const getItem = async (itemId: number) => {
 };
 
 // 항목 수정 (이미지 URL로 변환하는 과정 필요)
-interface UpdateItemProps {
+export interface UpdateItemProps {
   name?: string;
   memo?: string;
   imageUrl?: string;

--- a/services/axiosInstance.ts
+++ b/services/axiosInstance.ts
@@ -16,7 +16,7 @@ axiosInstance.interceptors.response.use(
     }
 
     return Promise.reject(error);
-  }
+  },
 );
 
 export default axiosInstance;


### PR DESCRIPTION
# 📗 작업 내용

### 이슈 내용
- Detail 페이지 구현

<br/>

### 변경 사항

- 할 일 수정, 삭제 기능 구현
- 이름 변경, 메모, 이미지 업로드, 완료상태 변경 기능 구현
- 모바일, 태블릿, 데스크탑 반응형 고려
- 커스텀훅으로 주요 로직 분리

<br/>

### 요구사항


**할 일 수정 기능**

- [x]  할 일 항목의 이름을 수정할 수 있나요?
- [x]  할 일의 진행 상태를 수정할 수 있나요?
- [x]  메모를 추가할 수 있나요?
- [x]  이미지를 첨부할 수 있나요? (이미지 파일 이름은 영어로만 이루어지고, 크기는 5MB 이하인가요?)
- [x]  `수정 완료` 버튼을 클릭했을 때 수정 사항이 반영되고 할 일 목록 페이지로 이동되나요?
- [x]  다시 할 일을 클릭했을 때 추가된 메모와 이미지가 잘 보이나요?
    
 **할 일 삭제 기능**

- [x]  `삭제하기` 버튼을 클릭했을 때 할 일이 삭제되고, 할 일 목록 페이지로 이동되나요?